### PR TITLE
feat(slimproto): add --slimproto control frontend for LMS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,4 +73,4 @@ ENV MPD_ADDR=0.0.0.0:6600 \
     CONFIG_PATH=/etc/direttampd/config.yaml
 
 # Run as daemon by default
-CMD ["/app/direttampd", "--daemon", "--mpd-addr", "${MPD_ADDR}", "--config", "${CONFIG_PATH}"]
+CMD ["/app/direttampd", "--mpd", "--mpd-addr", "${MPD_ADDR}", "--config", "${CONFIG_PATH}"]

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Run as an MPD server that any MPD client can connect to:
 
 ```bash
 # Start daemon (default: localhost:6600)
-direttampd --daemon
+direttampd --mpd
 
 # In another terminal, use MPD clients:
 mpc add http://radio.example.com/stream.mp3
@@ -96,6 +96,22 @@ mpc play
 
 # Or use ncmpcpp, ario, cantata, etc.
 ```
+
+### Slimproto (LMS / Lyrion) Mode
+
+Run as a Squeezebox-compatible player that registers with a Lyrion Music
+Server (LMS). LMS drives track selection and transport, direttampd fetches
+each HTTP stream and plays it through the MemoryPlay backend:
+
+```bash
+# Auto-discover the LMS server on the LAN
+direttampd --slimproto --slim-name "Living Room"
+
+# Or point at LMS explicitly
+direttampd --slimproto --slim-server 192.168.1.10 --slim-name "Living Room"
+```
+
+`--mpd` and `--slimproto` are mutually exclusive.
 
 ### Direct Mode
 
@@ -119,13 +135,13 @@ direttampd file:///intro.wav http://stream.com/main.mp3
 
 ```bash
 # Specify config file
-direttampd --config /path/to/config.yaml --daemon
+direttampd --config /path/to/config.yaml --mpd
 
 # Override target
-direttampd --target bedroom --daemon
+direttampd --target bedroom --mpd
 
 # Custom MPD listen address
-direttampd --mpd-addr 0.0.0.0:6600 --daemon
+direttampd --mpd-addr 0.0.0.0:6600 --mpd
 
 # List configured targets
 direttampd --list-targets

--- a/cmd/direttampd/main.go
+++ b/cmd/direttampd/main.go
@@ -14,18 +14,23 @@ import (
 	"github.com/famish99/direttampd/internal/memoryplay"
 	"github.com/famish99/direttampd/internal/mpd"
 	"github.com/famish99/direttampd/internal/player"
+	"github.com/famish99/direttampd/internal/slimproto"
 )
 
 var (
-	configPath  = flag.String("config", getDefaultConfigPath(), "Path to configuration file")
-	host        = flag.String("host", "", "MemoryPlay host IP address (default: ::1, port is auto-discovered)")
-	targetName  = flag.String("target", "", "Override preferred target by name")
-	listHosts   = flag.Bool("list-hosts", false, "List available MemoryPlay hosts and exit")
-	listTargets = flag.Bool("list-targets", false, "List available targets from MemoryPlay host and exit")
-	playFile    = flag.String("play", "", "Play a file or URL directly")
-	mpdAddr     = flag.String("mpd-addr", "localhost:6600", "MPD server listen address")
-	daemonMode  = flag.Bool("daemon", false, "Run as MPD server daemon (otherwise play URLs and exit)")
-	useNative   = flag.Bool("native", false, "Use native Go implementation instead of CGo for MemoryPlay protocol")
+	configPath    = flag.String("config", getDefaultConfigPath(), "Path to configuration file")
+	host          = flag.String("host", "", "MemoryPlay host IP address (default: ::1, port is auto-discovered)")
+	targetName    = flag.String("target", "", "Override preferred target by name")
+	listHosts     = flag.Bool("list-hosts", false, "List available MemoryPlay hosts and exit")
+	listTargets   = flag.Bool("list-targets", false, "List available targets from MemoryPlay host and exit")
+	playFile      = flag.String("play", "", "Play a file or URL directly")
+	mpdAddr       = flag.String("mpd-addr", "localhost:6600", "MPD server listen address")
+	mpdMode       = flag.Bool("mpd", false, "Run as MPD server daemon (mutually exclusive with --slimproto)")
+	slimprotoMode = flag.Bool("slimproto", false, "Run as a Slimproto (Lyrion/LMS) player (mutually exclusive with --mpd)")
+	slimServer    = flag.String("slim-server", "", "LMS server address (host or host:port); empty = UDP auto-discover")
+	slimName      = flag.String("slim-name", "direttampd", "Player name registered with LMS")
+	slimMAC       = flag.String("slim-mac", "", "Player MAC address (aa:bb:cc:dd:ee:ff); empty = derive from hostname")
+	useNative     = flag.Bool("native", false, "Use native Go implementation instead of CGo for MemoryPlay protocol")
 )
 
 func main() {
@@ -70,15 +75,26 @@ func main() {
 		}
 	}
 
+	// Mutually-exclusive daemon modes
+	if *mpdMode && *slimprotoMode {
+		log.Fatalf("--mpd and --slimproto cannot be used together")
+	}
+
 	// Create player
 	p, err := player.NewPlayer(cfg, *useNative)
 	if err != nil {
 		log.Fatalf("Failed to create player: %v", err)
 	}
 
-	// Daemon mode: run MPD server
-	if *daemonMode {
-		runDaemon(p)
+	// MPD daemon mode
+	if *mpdMode {
+		runMPD(p)
+		return
+	}
+
+	// Slimproto daemon mode
+	if *slimprotoMode {
+		runSlimproto(p, *slimServer, *slimName, *slimMAC)
 		return
 	}
 
@@ -105,17 +121,20 @@ func main() {
 		_, _ = fmt.Fprintf(os.Stderr, "\n  # Play multiple files\n")
 		_, _ = fmt.Fprintf(os.Stderr, "  %s track01.flac track02.flac track03.flac\n", os.Args[0])
 		_, _ = fmt.Fprintf(os.Stderr, "\n  # Run as MPD server daemon\n")
-		_, _ = fmt.Fprintf(os.Stderr, "  %s --daemon\n", os.Args[0])
+		_, _ = fmt.Fprintf(os.Stderr, "  %s --mpd\n", os.Args[0])
 		_, _ = fmt.Fprintf(os.Stderr, "  mpc add http://stream.example.com/radio.mp3\n")
 		_, _ = fmt.Fprintf(os.Stderr, "  mpc play\n")
+		_, _ = fmt.Fprintf(os.Stderr, "\n  # Run as a Slimproto (LMS) player\n")
+		_, _ = fmt.Fprintf(os.Stderr, "  %s --slimproto --slim-server 192.168.1.10 --slim-name \"Living Room\"\n", os.Args[0])
+		_, _ = fmt.Fprintf(os.Stderr, "  %s --slimproto   # auto-discover LMS on the LAN\n", os.Args[0])
 		os.Exit(1)
 	}
 
 	runDirect(p, urls)
 }
 
-// runDaemon runs the MPD server daemon
-func runDaemon(p *player.Player) {
+// runMPD runs the MPD server daemon
+func runMPD(p *player.Player) {
 	// Create and start MPD server
 	server := mpd.NewServer(*mpdAddr, p)
 	if err := server.Start(); err != nil {
@@ -125,6 +144,27 @@ func runDaemon(p *player.Player) {
 
 	log.Printf("Direttampd running in daemon mode")
 	log.Printf("Connect with MPD clients to %s", *mpdAddr)
+
+	// Wait for interrupt signal
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+
+	<-sigChan
+	log.Printf("\nShutting down...")
+}
+
+// runSlimproto runs as a Slimproto (LMS) player
+func runSlimproto(p *player.Player, server, name, mac string) {
+	client, err := slimproto.NewClient(slimprotoPlayerAdapter{p: p}, server, name, mac)
+	if err != nil {
+		log.Fatalf("Failed to create Slimproto client: %v", err)
+	}
+	if err := client.Start(); err != nil {
+		log.Fatalf("Failed to start Slimproto client: %v", err)
+	}
+	defer client.Stop()
+
+	log.Printf("Direttampd running as Slimproto player %q against %s", client.Name(), client.Server())
 
 	// Wait for interrupt signal
 	sigChan := make(chan os.Signal, 1)

--- a/cmd/direttampd/slimproto_adapter.go
+++ b/cmd/direttampd/slimproto_adapter.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"github.com/famish99/direttampd/internal/player"
+	"github.com/famish99/direttampd/internal/slimproto"
+)
+
+// slimprotoPlayerAdapter wraps *player.Player to satisfy slimproto.Controller
+// without leaking the player package into internal/slimproto.
+type slimprotoPlayerAdapter struct {
+	p *player.Player
+}
+
+func (a slimprotoPlayerAdapter) ClearPlaylist()            { a.p.GetPlaylist().Clear() }
+func (a slimprotoPlayerAdapter) AddURLs(urls []string)     { a.p.AddURLs(urls) }
+func (a slimprotoPlayerAdapter) Play() error               { return a.p.Play() }
+func (a slimprotoPlayerAdapter) Pause() error              { return a.p.Pause() }
+func (a slimprotoPlayerAdapter) Resume() error             { return a.p.Resume() }
+func (a slimprotoPlayerAdapter) Stop() error               { return a.p.Stop() }
+
+func (a slimprotoPlayerAdapter) GetState() slimproto.PlaybackState {
+	switch a.p.GetState() {
+	case player.StatePlaying:
+		return slimproto.StatePlaying
+	case player.StatePaused:
+		return slimproto.StatePaused
+	default:
+		return slimproto.StateStopped
+	}
+}
+
+func (a slimprotoPlayerAdapter) GetPlaybackTiming() *slimproto.PlaybackTiming {
+	t := a.p.GetPlaybackTiming()
+	if t == nil {
+		return nil
+	}
+	return &slimproto.PlaybackTiming{
+		Elapsed:   t.Elapsed,
+		Duration:  t.Duration,
+		Remaining: t.Remaining,
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - CONFIG_PATH=/etc/direttampd/config.yaml
 
     # Optional: Use native Go implementation instead of CGo
-    # command: ["/app/direttampd", "--daemon", "--native", "--mpd-addr", "0.0.0.0:6600"]
+    # command: ["/app/direttampd", "--mpd", "--native", "--mpd-addr", "0.0.0.0:6600"]
     command: ["/app/direttampd", "-host", "fd6a:4520:9ef6:44da:d2fd:7871:2ddb:2042", "-list-targets"]
 
   upmpdcli:

--- a/internal/slimproto/client.go
+++ b/internal/slimproto/client.go
@@ -1,0 +1,431 @@
+package slimproto
+
+import (
+	"bufio"
+	"crypto/sha1"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// PlaybackState mirrors player.PlaybackState so slimproto does not depend on
+// the player package (which transitively requires the CGo Diretta SDK).
+type PlaybackState int
+
+const (
+	StateStopped PlaybackState = iota
+	StatePlaying
+	StatePaused
+)
+
+// PlaybackTiming mirrors player.PlaybackTiming. Seconds everywhere.
+type PlaybackTiming struct {
+	Elapsed   int64
+	Duration  int64
+	Remaining int64
+}
+
+// Controller is the slice of *player.Player that slimproto uses. An adapter
+// in cmd/direttampd wraps the real player to satisfy it.
+type Controller interface {
+	ClearPlaylist()
+	AddURLs(urls []string)
+	Play() error
+	Pause() error
+	Resume() error
+	Stop() error
+	GetState() PlaybackState
+	GetPlaybackTiming() *PlaybackTiming
+}
+
+const (
+	defaultControlPort = "3483"
+	discoveryTimeout   = 3 * time.Second
+	statInterval       = time.Second
+)
+
+// Client is a Slimproto TCP client that presents direttampd to LMS as a
+// Squeezebox-compatible player and drives the local Controller in response
+// to LMS commands.
+type Client struct {
+	player Controller
+	server string
+	name   string
+	mac    [6]byte
+
+	conn net.Conn
+	bw   *bufio.Writer
+
+	writeMu sync.Mutex
+
+	stopCh    chan struct{}
+	stoppedCh chan struct{}
+
+	// streamActive is true between STRM-start and either STRM-flush, STRM-quit,
+	// or natural end-of-stream. It gates sending spurious STMd/STMu frames when
+	// the player stops for reasons not driven by LMS.
+	streamActive atomic.Bool
+
+	// stageDir is the on-disk directory into which LMS HTTP streams are fetched
+	// before handing them to player.Player.
+	stageDir string
+
+	// startTime is set when Start() succeeds; elapsed time since start is used
+	// for the STAT "jiffies" field.
+	startTime time.Time
+
+	// bytesReceived is the running total of audio bytes staged from LMS (for
+	// STAT reporting).
+	bytesReceived atomic.Uint64
+
+	// serverTimestamp is echoed back to LMS in STAT frames when the server
+	// sends a timed 't' command.
+	serverTimestamp atomic.Uint32
+}
+
+// NewClient builds a Slimproto client. If server is empty the LMS server is
+// auto-discovered over UDP broadcast. mac may be empty; a stable MAC is then
+// derived from the hostname.
+func NewClient(p Controller, server, name, mac string) (*Client, error) {
+	if p == nil {
+		return nil, fmt.Errorf("slimproto: player is required")
+	}
+
+	resolved := server
+	if resolved == "" {
+		addr, err := DiscoverServer(discoveryTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("auto-discover LMS: %w", err)
+		}
+		log.Printf("slimproto: discovered LMS at %s", addr)
+		resolved = addr
+	} else if !strings.Contains(resolved, ":") {
+		resolved = net.JoinHostPort(resolved, defaultControlPort)
+	}
+
+	macBytes, err := parseOrDeriveMAC(mac)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		player:    p,
+		server:    resolved,
+		name:      name,
+		mac:       macBytes,
+		stopCh:    make(chan struct{}),
+		stoppedCh: make(chan struct{}),
+		stageDir:  filepath.Join(os.TempDir(), "direttampd-slimproto"),
+	}, nil
+}
+
+// Name returns the player name registered with LMS.
+func (c *Client) Name() string { return c.name }
+
+// Server returns the resolved LMS server address (host:port).
+func (c *Client) Server() string { return c.server }
+
+// Start dials LMS, sends HELO, and launches the read loop and STAT ticker.
+// It returns once the connection is established; subsequent protocol errors
+// are logged and will terminate the background goroutines.
+func (c *Client) Start() error {
+	conn, err := net.DialTimeout("tcp", c.server, 5*time.Second)
+	if err != nil {
+		return fmt.Errorf("dial LMS: %w", err)
+	}
+	c.conn = conn
+	c.bw = bufio.NewWriter(conn)
+	c.startTime = time.Now()
+
+	if err := c.sendHELO(); err != nil {
+		conn.Close()
+		return fmt.Errorf("send HELO: %w", err)
+	}
+	log.Printf("slimproto: sent HELO as %q (%02x:%02x:%02x:%02x:%02x:%02x) to %s",
+		c.name, c.mac[0], c.mac[1], c.mac[2], c.mac[3], c.mac[4], c.mac[5], c.server)
+
+	go c.readLoop()
+	go c.statLoop()
+	return nil
+}
+
+// Stop tears down the client. Safe to call multiple times.
+func (c *Client) Stop() {
+	select {
+	case <-c.stopCh:
+		return
+	default:
+	}
+	close(c.stopCh)
+	if c.conn != nil {
+		// Best-effort BYE! before closing.
+		_ = c.writeFrame(OpBYE, []byte{0})
+		_ = c.conn.Close()
+	}
+	<-c.stoppedCh
+}
+
+func (c *Client) sendHELO() error {
+	hello := HelloInfo{
+		DeviceID:     12, // "Squeezeplay" class — software player
+		Revision:     1,
+		MAC:          c.mac,
+		Language:     [2]byte{'e', 'n'},
+		Capabilities: "Model=direttampd,ModelName=direttampd,flc,mp3,aac,ogg,pcm",
+	}
+	return c.writeFrame(OpHELO, EncodeHELO(hello))
+}
+
+func (c *Client) writeFrame(op Op, payload []byte) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	if c.bw == nil {
+		return fmt.Errorf("slimproto: not connected")
+	}
+	if err := WriteClientFrame(c.bw, op, payload); err != nil {
+		return err
+	}
+	return c.bw.Flush()
+}
+
+func (c *Client) readLoop() {
+	defer close(c.stoppedCh)
+
+	br := bufio.NewReader(c.conn)
+	for {
+		select {
+		case <-c.stopCh:
+			return
+		default:
+		}
+
+		frame, err := ReadServerFrame(br)
+		if err != nil {
+			log.Printf("slimproto: read error: %v", err)
+			return
+		}
+
+		switch frame.Op {
+		case OpStrm:
+			c.handleStrm(frame.Payload)
+		case OpAudg, OpAude, OpSetd, OpServ, OpVers:
+			log.Printf("slimproto: ignoring %s frame (%d bytes)", string(frame.Op[:]), len(frame.Payload))
+		default:
+			log.Printf("slimproto: unknown op %q (%d bytes)", string(frame.Op[:]), len(frame.Payload))
+		}
+	}
+}
+
+func (c *Client) handleStrm(payload []byte) {
+	cmd, err := DecodeStrm(payload)
+	if err != nil {
+		log.Printf("slimproto: decode strm: %v", err)
+		return
+	}
+
+	switch cmd.Command {
+	case 's': // start
+		c.handleStrmStart(cmd)
+	case 'p': // pause
+		log.Printf("slimproto: pause")
+		if err := c.player.Pause(); err != nil {
+			log.Printf("slimproto: player.Pause: %v", err)
+		}
+		c.sendSimpleStat(StatSTMp)
+	case 'u': // unpause / resume
+		log.Printf("slimproto: resume")
+		if err := c.player.Resume(); err != nil {
+			log.Printf("slimproto: player.Resume: %v", err)
+		}
+		c.sendSimpleStat(StatSTMr)
+	case 'q': // quit/stop
+		log.Printf("slimproto: quit")
+		c.streamActive.Store(false)
+		if err := c.player.Stop(); err != nil {
+			log.Printf("slimproto: player.Stop: %v", err)
+		}
+		c.sendSimpleStat(StatSTMf)
+	case 'f': // flush
+		log.Printf("slimproto: flush")
+		c.streamActive.Store(false)
+		if err := c.player.Stop(); err != nil {
+			log.Printf("slimproto: player.Stop: %v", err)
+		}
+		c.sendSimpleStat(StatSTMf)
+	case 't': // timestamp echo
+		c.serverTimestamp.Store(cmd.ReplayGain)
+		c.sendSimpleStat(StatSTMt)
+	case 'a': // skip-ahead (seek) – we simply restart the stream; LMS will send the new strm
+		log.Printf("slimproto: skip-ahead")
+	default:
+		log.Printf("slimproto: unhandled strm cmd %q", cmd.Command)
+	}
+}
+
+func (c *Client) handleStrmStart(cmd StrmCmd) {
+	serverHost, _, err := net.SplitHostPort(c.server)
+	if err != nil {
+		serverHost = c.server
+	}
+	port := cmd.ServerPort
+	if port == 0 {
+		port = 9000
+	}
+	path := cmd.HTTPRequestPath()
+	url := fmt.Sprintf("http://%s:%d%s", serverHost, port, path)
+
+	log.Printf("slimproto: STRM-start %s (format=%c)", url, printableOrDot(cmd.FormatCode))
+
+	c.sendSimpleStat(StatSTMc)
+
+	// Stage synchronously: LMS will happily wait for STMs while we download the
+	// body, and the existing player pipeline wants a local file anyway.
+	base := strings.ReplaceAll(strings.Trim(path, "/"), "/", "_")
+	if base == "" {
+		base = fmt.Sprintf("stream-%d", time.Now().UnixNano())
+	}
+	// Append a format-friendly extension so ffprobe can detect the codec.
+	if ext := formatExtension(cmd.FormatCode); ext != "" && !strings.HasSuffix(base, ext) {
+		base += ext
+	}
+
+	res, err := stageToFile(url, c.stageDir, base)
+	if err != nil {
+		log.Printf("slimproto: stage: %v", err)
+		c.sendSimpleStat(StatSTMn)
+		return
+	}
+	c.bytesReceived.Add(uint64(res.BytesRead))
+	c.sendSimpleStat(StatSTMh)
+	c.sendSimpleStat(StatSTMe)
+
+	// Clear the playlist and queue exactly the new track.
+	c.player.ClearPlaylist()
+	c.player.AddURLs([]string{"file://" + res.Path})
+	c.streamActive.Store(true)
+
+	if err := c.player.Play(); err != nil {
+		log.Printf("slimproto: player.Play: %v", err)
+		c.sendSimpleStat(StatSTMn)
+		c.streamActive.Store(false)
+		return
+	}
+
+	c.sendSimpleStat(StatSTMs)
+}
+
+// statLoop periodically emits STMt heartbeats with current elapsed time, and
+// watches for natural end-of-track so it can tell LMS to move on.
+func (c *Client) statLoop() {
+	ticker := time.NewTicker(statInterval)
+	defer ticker.Stop()
+
+	var lastState PlaybackState
+	for {
+		select {
+		case <-c.stopCh:
+			return
+		case <-ticker.C:
+		}
+
+		state := c.player.GetState()
+
+		// Detect natural end-of-track: previously Playing, now Stopped, and we
+		// were expecting to be playing.
+		if lastState == StatePlaying && state == StateStopped && c.streamActive.Load() {
+			log.Printf("slimproto: track ended naturally, notifying LMS")
+			c.streamActive.Store(false)
+			c.sendSimpleStat(StatSTMd)
+			c.sendSimpleStat(StatSTMu)
+		}
+		lastState = state
+
+		if state == StatePlaying || state == StatePaused {
+			c.sendSimpleStat(StatSTMt)
+		}
+	}
+}
+
+func (c *Client) sendSimpleStat(event StatEvent) {
+	timing := c.player.GetPlaybackTiming()
+	var elapsedSec, elapsedMs uint32
+	if timing != nil {
+		elapsedSec = uint32(timing.Elapsed)
+		elapsedMs = uint32(timing.Elapsed * 1000)
+	}
+	stat := StatInfo{
+		Event:           event,
+		BytesReceived:   c.bytesReceived.Load(),
+		JiffiesMs:       uint32(time.Since(c.startTime) / time.Millisecond),
+		ElapsedSeconds:  elapsedSec,
+		ElapsedMs:       elapsedMs,
+		ServerTimestamp: c.serverTimestamp.Load(),
+	}
+	if err := c.writeFrame(OpSTAT, EncodeSTAT(stat)); err != nil {
+		log.Printf("slimproto: send STAT %s: %v", string(event[:]), err)
+	}
+}
+
+// parseOrDeriveMAC returns a 6-byte MAC. If s is empty, a stable MAC is
+// derived from the hostname (local-admin bit set).
+func parseOrDeriveMAC(s string) ([6]byte, error) {
+	var out [6]byte
+	if s == "" {
+		host, err := os.Hostname()
+		if err != nil {
+			host = "direttampd"
+		}
+		sum := sha1.Sum([]byte(host))
+		copy(out[:], sum[:6])
+		out[0] = (out[0] | 0x02) & 0xFE // locally administered, unicast
+		return out, nil
+	}
+
+	parts := strings.Split(s, ":")
+	if len(parts) != 6 {
+		return out, fmt.Errorf("slimproto: invalid MAC %q: need 6 colon-separated octets", s)
+	}
+	for i, p := range parts {
+		if len(p) == 0 || len(p) > 2 {
+			return out, fmt.Errorf("slimproto: invalid MAC octet %q", p)
+		}
+		v, err := strconv.ParseUint(p, 16, 8)
+		if err != nil {
+			return out, fmt.Errorf("slimproto: invalid MAC octet %q: %w", p, err)
+		}
+		out[i] = byte(v)
+	}
+	return out, nil
+}
+
+func formatExtension(code byte) string {
+	switch code {
+	case 'f':
+		return ".flac"
+	case 'm':
+		return ".mp3"
+	case 'a':
+		return ".aac"
+	case 'o':
+		return ".ogg"
+	case 'p':
+		return ".pcm"
+	default:
+		return ""
+	}
+}
+
+func printableOrDot(b byte) rune {
+	if b >= 0x20 && b < 0x7f {
+		return rune(b)
+	}
+	return '.'
+}
+

--- a/internal/slimproto/discovery.go
+++ b/internal/slimproto/discovery.go
@@ -1,0 +1,58 @@
+package slimproto
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"time"
+)
+
+// DiscoverServer broadcasts an LMS discovery probe on UDP 3483 and returns
+// the address of the first server that responds. Response parsing follows the
+// documented format: packet starts with 'E' and is followed by TLV sections
+// where the 'IPAD' tag (when present) carries the server IP, and the JSON
+// RPC port defaults to 9000 / control port to 3483.
+//
+// The returned server string is in "host:port" form with control port 3483,
+// suitable for net.Dial("tcp", ...).
+func DiscoverServer(timeout time.Duration) (string, error) {
+	addr, err := net.ResolveUDPAddr("udp4", "255.255.255.255:3483")
+	if err != nil {
+		return "", fmt.Errorf("resolve broadcast addr: %w", err)
+	}
+
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
+	if err != nil {
+		return "", fmt.Errorf("open udp socket: %w", err)
+	}
+	defer conn.Close()
+
+	// Enable SO_BROADCAST via setting (Go's ListenUDP sets it implicitly on Linux).
+	// Discovery probe: byte 'e' followed by a NAME request tag.
+	probe := []byte("eIPAD\x00NAME\x00JSON\x00")
+
+	if _, err := conn.WriteTo(probe, addr); err != nil {
+		return "", fmt.Errorf("send discovery probe: %w", err)
+	}
+
+	if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+		return "", fmt.Errorf("set deadline: %w", err)
+	}
+
+	buf := make([]byte, 1500)
+	n, src, err := conn.ReadFromUDP(buf)
+	if err != nil {
+		var nerr net.Error
+		if errors.As(err, &nerr) && nerr.Timeout() {
+			return "", fmt.Errorf("no LMS server responded within %s", timeout)
+		}
+		return "", fmt.Errorf("read discovery reply: %w", err)
+	}
+	if n < 1 || (buf[0] != 'E' && buf[0] != 'e') {
+		return "", fmt.Errorf("unexpected discovery reply from %s", src.String())
+	}
+
+	// We use the source IP of the reply as the server address; the control
+	// port is always 3483.
+	return net.JoinHostPort(src.IP.String(), "3483"), nil
+}

--- a/internal/slimproto/messages.go
+++ b/internal/slimproto/messages.go
@@ -1,0 +1,171 @@
+package slimproto
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"strings"
+)
+
+// HelloInfo is the client identity sent in a HELO frame.
+type HelloInfo struct {
+	DeviceID     uint8  // LMS device class; 12 = "Squeezeplay", used by software players
+	Revision     uint8  // Firmware revision (informational)
+	MAC          [6]byte
+	UUID         [16]byte // Optional, zero is acceptable
+	WLANChannels uint16   // Unused for wired players; 0
+	BytesRecv    uint64   // 0 on connect
+	Language     [2]byte  // e.g. 'e','n'
+	Capabilities string   // Comma-separated capability list
+}
+
+// EncodeHELO returns the payload of a HELO frame ready to pass to
+// WriteClientFrame together with OpHELO.
+func EncodeHELO(h HelloInfo) []byte {
+	var buf bytes.Buffer
+	buf.WriteByte(h.DeviceID)
+	buf.WriteByte(h.Revision)
+	buf.Write(h.MAC[:])
+	buf.Write(h.UUID[:])
+	_ = binary.Write(&buf, binary.BigEndian, h.WLANChannels)
+	_ = binary.Write(&buf, binary.BigEndian, h.BytesRecv)
+	buf.Write(h.Language[:])
+	buf.WriteString(h.Capabilities)
+	return buf.Bytes()
+}
+
+// StatEvent is the 4-ASCII-byte event code that identifies a STAT frame's
+// meaning to LMS.
+type StatEvent [4]byte
+
+// STAT event codes per the public Slimproto documentation.
+var (
+	StatSTMa = StatEvent{'S', 'T', 'M', 'a'} // autostart: audio available in buffer
+	StatSTMc = StatEvent{'S', 'T', 'M', 'c'} // connect
+	StatSTMd = StatEvent{'S', 'T', 'M', 'd'} // decoder ready / needs next track
+	StatSTMe = StatEvent{'S', 'T', 'M', 'e'} // connection established
+	StatSTMf = StatEvent{'S', 'T', 'M', 'f'} // connection flushed
+	StatSTMh = StatEvent{'S', 'T', 'M', 'h'} // end-of-headers
+	StatSTMl = StatEvent{'S', 'T', 'M', 'l'} // buffer threshold reached
+	StatSTMo = StatEvent{'S', 'T', 'M', 'o'} // output buffer underrun
+	StatSTMp = StatEvent{'S', 'T', 'M', 'p'} // paused
+	StatSTMr = StatEvent{'S', 'T', 'M', 'r'} // resumed
+	StatSTMs = StatEvent{'S', 'T', 'M', 's'} // track started
+	StatSTMt = StatEvent{'S', 'T', 'M', 't'} // timer / heartbeat
+	StatSTMu = StatEvent{'S', 'T', 'M', 'u'} // underrun / end of data
+	StatSTMn = StatEvent{'S', 'T', 'M', 'n'} // decoding error
+)
+
+// StatInfo is the payload of a STAT frame.
+// Field sizes and ordering follow the documented 53-byte structure.
+type StatInfo struct {
+	Event            StatEvent
+	CRLFs            uint8  // number of consecutive CRLFs parsed
+	MASInitialized   uint8  // 'm' or 'p'
+	MASMode          uint8  // 0
+	BufferSize       uint32 // decode buffer size
+	BufferFullness   uint32 // bytes queued in decode buffer
+	BytesReceived    uint64 // total bytes received on stream
+	SignalStrength   uint16 // 0-100, 0 for wired
+	JiffiesMs        uint32 // ms timestamp
+	OutputSize       uint32 // output buffer size
+	OutputFullness   uint32 // bytes queued in output buffer
+	ElapsedSeconds   uint32 // playback elapsed, seconds
+	VoltageMv        uint16 // battery millivolts or 0
+	ElapsedMs        uint32 // playback elapsed, milliseconds
+	ServerTimestamp  uint32 // echoed from server 't' command
+	ErrorCode        uint16 // 0 ok
+}
+
+// EncodeSTAT returns the payload of a STAT frame.
+func EncodeSTAT(s StatInfo) []byte {
+	buf := make([]byte, 0, 53)
+	buf = append(buf, s.Event[:]...)
+	buf = append(buf, s.CRLFs, s.MASInitialized, s.MASMode)
+	buf = binary.BigEndian.AppendUint32(buf, s.BufferSize)
+	buf = binary.BigEndian.AppendUint32(buf, s.BufferFullness)
+	buf = binary.BigEndian.AppendUint64(buf, s.BytesReceived)
+	buf = binary.BigEndian.AppendUint16(buf, s.SignalStrength)
+	buf = binary.BigEndian.AppendUint32(buf, s.JiffiesMs)
+	buf = binary.BigEndian.AppendUint32(buf, s.OutputSize)
+	buf = binary.BigEndian.AppendUint32(buf, s.OutputFullness)
+	buf = binary.BigEndian.AppendUint32(buf, s.ElapsedSeconds)
+	buf = binary.BigEndian.AppendUint16(buf, s.VoltageMv)
+	buf = binary.BigEndian.AppendUint32(buf, s.ElapsedMs)
+	buf = binary.BigEndian.AppendUint32(buf, s.ServerTimestamp)
+	buf = binary.BigEndian.AppendUint16(buf, s.ErrorCode)
+	return buf
+}
+
+// StrmCmd is a decoded server 'strm' frame.
+type StrmCmd struct {
+	Command        byte   // 's','p','u','q','t','f','a','0'..'4'
+	Autostart      byte   // '0','1','2','3'
+	FormatCode     byte   // 'p' pcm, 'f' flac, 'm' mp3, 'o' ogg, 'a' aac
+	PCMSampleSize  byte
+	PCMSampleRate  byte
+	PCMChannels    byte
+	PCMEndianness  byte
+	Threshold      uint8  // buffer threshold (KB)
+	SpdifEnable    byte
+	TransitionPer  uint8
+	TransitionType byte
+	Flags          byte
+	OutputThresh   uint8
+	Reserved       byte
+	ReplayGain     uint32
+	ServerPort     uint16
+	ServerIP       uint32 // 0 = same as control server
+	HTTPRequest    []byte // verbatim HTTP request bytes LMS wants us to send
+}
+
+// DecodeStrm parses a 'strm' payload.
+// Returns an error if the payload is shorter than the fixed 24-byte header.
+func DecodeStrm(payload []byte) (StrmCmd, error) {
+	if len(payload) < 24 {
+		return StrmCmd{}, fmt.Errorf("slimproto: strm payload too short (%d < 24)", len(payload))
+	}
+	c := StrmCmd{
+		Command:        payload[0],
+		Autostart:      payload[1],
+		FormatCode:     payload[2],
+		PCMSampleSize:  payload[3],
+		PCMSampleRate:  payload[4],
+		PCMChannels:    payload[5],
+		PCMEndianness:  payload[6],
+		Threshold:      payload[7],
+		SpdifEnable:    payload[8],
+		TransitionPer:  payload[9],
+		TransitionType: payload[10],
+		Flags:          payload[11],
+		OutputThresh:   payload[12],
+		Reserved:       payload[13],
+		ReplayGain:     binary.BigEndian.Uint32(payload[14:18]),
+		ServerPort:     binary.BigEndian.Uint16(payload[18:20]),
+		ServerIP:       binary.BigEndian.Uint32(payload[20:24]),
+	}
+	if len(payload) > 24 {
+		c.HTTPRequest = append([]byte(nil), payload[24:]...)
+	}
+	return c, nil
+}
+
+// HTTPRequestPath extracts the request path from the verbatim HTTP request
+// bytes LMS embedded in the strm payload, e.g. "/stream.mp3?player=xx".
+// Returns "/" if the request line cannot be parsed.
+func (c StrmCmd) HTTPRequestPath() string {
+	if len(c.HTTPRequest) == 0 {
+		return "/"
+	}
+	line := c.HTTPRequest
+	if idx := bytes.IndexByte(line, '\r'); idx >= 0 {
+		line = line[:idx]
+	} else if idx := bytes.IndexByte(line, '\n'); idx >= 0 {
+		line = line[:idx]
+	}
+	parts := strings.SplitN(string(line), " ", 3)
+	if len(parts) < 2 {
+		return "/"
+	}
+	return parts[1]
+}

--- a/internal/slimproto/protocol.go
+++ b/internal/slimproto/protocol.go
@@ -1,0 +1,84 @@
+// Package slimproto implements the client side of the Lyrion/Squeezebox
+// "Slimproto" control protocol, enough to register direttampd as an LMS player
+// and receive start/stop/pause/seek commands. It is a clean-room Go
+// implementation based on public documentation (wiki.lyrion.org) and does not
+// reference any GPL source from Squeezelite.
+package slimproto
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+// Op is a 4-byte operation code exchanged on the Slimproto TCP connection.
+// Server -> client op codes ("strm", "audg", ...) and
+// client -> server op codes ("HELO", "STAT", "RESP", "BYE!", ...) both use
+// 4 ASCII bytes, but the framing differs: server frames prefix the op with a
+// 2-byte big-endian length, client frames prefix the length *after* the op.
+type Op [4]byte
+
+// Server-to-client op codes that we handle or explicitly ignore.
+var (
+	OpStrm = Op{'s', 't', 'r', 'm'}
+	OpAudg = Op{'a', 'u', 'd', 'g'}
+	OpAude = Op{'a', 'u', 'd', 'e'}
+	OpSetd = Op{'s', 'e', 't', 'd'}
+	OpServ = Op{'s', 'e', 'r', 'v'}
+	OpVers = Op{'v', 'e', 'r', 's'}
+)
+
+// Client-to-server op codes we emit.
+var (
+	OpHELO = Op{'H', 'E', 'L', 'O'}
+	OpSTAT = Op{'S', 'T', 'A', 'T'}
+	OpRESP = Op{'R', 'E', 'S', 'P'}
+	OpBYE  = Op{'B', 'Y', 'E', '!'}
+	OpMETA = Op{'M', 'E', 'T', 'A'}
+)
+
+// ServerFrame is a frame received from LMS.
+type ServerFrame struct {
+	Op      Op
+	Payload []byte
+}
+
+// ReadServerFrame reads a single server->client frame from r.
+// Server frames are: [2-byte BE length][4-byte op][payload...]
+// where the length value includes the 4-byte op (so payload = length - 4).
+func ReadServerFrame(r io.Reader) (ServerFrame, error) {
+	var header [6]byte
+	if _, err := io.ReadFull(r, header[:]); err != nil {
+		return ServerFrame{}, err
+	}
+	length := binary.BigEndian.Uint16(header[0:2])
+	if length < 4 {
+		return ServerFrame{}, fmt.Errorf("slimproto: server frame length %d < 4", length)
+	}
+	var op Op
+	copy(op[:], header[2:6])
+
+	payload := make([]byte, int(length)-4)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return ServerFrame{}, err
+	}
+	return ServerFrame{Op: op, Payload: payload}, nil
+}
+
+// WriteClientFrame writes a single client->server frame to w.
+// Client frames are: [4-byte op][4-byte BE length][payload...]
+// where length is the payload length (not including op or length field).
+func WriteClientFrame(w io.Writer, op Op, payload []byte) error {
+	var header [8]byte
+	copy(header[0:4], op[:])
+	binary.BigEndian.PutUint32(header[4:8], uint32(len(payload)))
+	if _, err := w.Write(header[:]); err != nil {
+		return err
+	}
+	if len(payload) > 0 {
+		if _, err := w.Write(payload); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/slimproto/slimproto_test.go
+++ b/internal/slimproto/slimproto_test.go
@@ -1,0 +1,186 @@
+package slimproto
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+func TestServerFrameRoundTripViaBuffer(t *testing.T) {
+	// Build a server frame manually: [len BE u16][op 4 bytes][payload]
+	payload := []byte("hello-payload")
+	total := 4 + len(payload)
+	buf := new(bytes.Buffer)
+	_ = binary.Write(buf, binary.BigEndian, uint16(total))
+	buf.Write([]byte{'s', 't', 'r', 'm'})
+	buf.Write(payload)
+
+	frame, err := ReadServerFrame(buf)
+	if err != nil {
+		t.Fatalf("ReadServerFrame: %v", err)
+	}
+	if frame.Op != OpStrm {
+		t.Errorf("op: got %q, want strm", string(frame.Op[:]))
+	}
+	if !bytes.Equal(frame.Payload, payload) {
+		t.Errorf("payload: got %q, want %q", frame.Payload, payload)
+	}
+}
+
+func TestReadServerFrameRejectsTooShortLength(t *testing.T) {
+	buf := new(bytes.Buffer)
+	_ = binary.Write(buf, binary.BigEndian, uint16(2)) // < 4
+	buf.Write([]byte{'x', 'x'})
+
+	if _, err := ReadServerFrame(buf); err == nil {
+		t.Fatal("expected error for length < 4")
+	}
+}
+
+func TestWriteClientFrame(t *testing.T) {
+	buf := new(bytes.Buffer)
+	if err := WriteClientFrame(buf, OpHELO, []byte{1, 2, 3}); err != nil {
+		t.Fatalf("WriteClientFrame: %v", err)
+	}
+	got := buf.Bytes()
+	// [H E L O][00 00 00 03][01 02 03]
+	want := []byte{'H', 'E', 'L', 'O', 0, 0, 0, 3, 1, 2, 3}
+	if !bytes.Equal(got, want) {
+		t.Errorf("frame bytes: got %v, want %v", got, want)
+	}
+}
+
+func TestEncodeHELO(t *testing.T) {
+	h := HelloInfo{
+		DeviceID:     12,
+		Revision:     1,
+		MAC:          [6]byte{0x02, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE},
+		Language:     [2]byte{'e', 'n'},
+		Capabilities: "Model=direttampd,flc",
+	}
+	out := EncodeHELO(h)
+	// 1 + 1 + 6 + 16 + 2 + 8 + 2 = 36 bytes of fixed header + caps
+	if len(out) != 36+len(h.Capabilities) {
+		t.Fatalf("HELO size: got %d, want %d", len(out), 36+len(h.Capabilities))
+	}
+	if out[0] != 12 || out[1] != 1 {
+		t.Errorf("device/revision: got %d/%d", out[0], out[1])
+	}
+	if !bytes.Equal(out[2:8], h.MAC[:]) {
+		t.Errorf("MAC mismatch")
+	}
+	if !bytes.HasSuffix(out, []byte(h.Capabilities)) {
+		t.Errorf("capabilities suffix missing")
+	}
+}
+
+func TestEncodeSTATSize(t *testing.T) {
+	out := EncodeSTAT(StatInfo{Event: StatSTMt})
+	if len(out) != 53 {
+		t.Errorf("STAT payload size: got %d, want 53", len(out))
+	}
+	if !bytes.HasPrefix(out, []byte{'S', 'T', 'M', 't'}) {
+		t.Errorf("STAT event prefix: got %q", out[:4])
+	}
+}
+
+func TestDecodeStrmHeaderAndPath(t *testing.T) {
+	// Build a minimal strm payload: 24-byte header + HTTP request line.
+	httpReq := "GET /stream.mp3?player=ab%3Acd HTTP/1.0\r\n\r\n"
+	header := make([]byte, 24)
+	header[0] = 's'                         // command
+	header[1] = '1'                         // autostart
+	header[2] = 'm'                         // format: mp3
+	binary.BigEndian.PutUint16(header[18:20], 9000) // server port
+	payload := append(header, []byte(httpReq)...)
+
+	cmd, err := DecodeStrm(payload)
+	if err != nil {
+		t.Fatalf("DecodeStrm: %v", err)
+	}
+	if cmd.Command != 's' || cmd.FormatCode != 'm' || cmd.ServerPort != 9000 {
+		t.Errorf("fields: %+v", cmd)
+	}
+	if got := cmd.HTTPRequestPath(); got != "/stream.mp3?player=ab%3Acd" {
+		t.Errorf("path: got %q", got)
+	}
+}
+
+func TestDecodeStrmShortPayload(t *testing.T) {
+	if _, err := DecodeStrm(make([]byte, 10)); err == nil {
+		t.Fatal("expected error for short payload")
+	}
+}
+
+func TestParseOrDeriveMACExplicit(t *testing.T) {
+	mac, err := parseOrDeriveMAC("00:11:22:33:44:55")
+	if err != nil {
+		t.Fatalf("parseOrDeriveMAC: %v", err)
+	}
+	want := [6]byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}
+	if mac != want {
+		t.Errorf("MAC: got %v, want %v", mac, want)
+	}
+}
+
+func TestParseOrDeriveMACInvalid(t *testing.T) {
+	for _, in := range []string{"", "xx:yy", "00:11:22:33:44", "00:11:22:33:44:55:66", "00:11:22:33:44:zz"} {
+		if in == "" {
+			continue // empty triggers hostname-derived MAC path, tested separately
+		}
+		if _, err := parseOrDeriveMAC(in); err == nil {
+			t.Errorf("expected error for %q", in)
+		}
+	}
+}
+
+func TestParseOrDeriveMACFromHostname(t *testing.T) {
+	mac, err := parseOrDeriveMAC("")
+	if err != nil {
+		t.Fatalf("parseOrDeriveMAC(\"\"): %v", err)
+	}
+	// Locally-administered bit must be set, multicast bit cleared.
+	if mac[0]&0x02 == 0 {
+		t.Errorf("local-admin bit not set: %02x", mac[0])
+	}
+	if mac[0]&0x01 != 0 {
+		t.Errorf("multicast bit set: %02x", mac[0])
+	}
+}
+
+func TestFormatExtension(t *testing.T) {
+	cases := map[byte]string{
+		'f': ".flac",
+		'm': ".mp3",
+		'a': ".aac",
+		'o': ".ogg",
+		'p': ".pcm",
+		'?': "",
+	}
+	for in, want := range cases {
+		if got := formatExtension(in); got != want {
+			t.Errorf("formatExtension(%q): got %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestHTTPRequestPathFallback(t *testing.T) {
+	cmd := StrmCmd{HTTPRequest: []byte("GET\r\n")}
+	if got := cmd.HTTPRequestPath(); got != "/" {
+		t.Errorf("fallback path: got %q, want /", got)
+	}
+	cmd = StrmCmd{}
+	if got := cmd.HTTPRequestPath(); got != "/" {
+		t.Errorf("empty path: got %q, want /", got)
+	}
+}
+
+func TestEncodeHELOCapabilitiesASCII(t *testing.T) {
+	h := HelloInfo{Capabilities: "Model=x,flc"}
+	out := EncodeHELO(h)
+	tail := string(out[len(out)-len(h.Capabilities):])
+	if !strings.HasPrefix(tail, "Model=") {
+		t.Errorf("capabilities not at tail: %q", tail)
+	}
+}

--- a/internal/slimproto/stage.go
+++ b/internal/slimproto/stage.go
@@ -1,0 +1,56 @@
+package slimproto
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+// stageResult reports the outcome of fetching an LMS HTTP stream to disk.
+type stageResult struct {
+	Path       string
+	BytesRead  int64
+	StatusCode int
+}
+
+// stageToFile downloads a single HTTP URL (LMS stream) to a local file under
+// dir and returns the local path and bytes read. It overwrites any existing
+// file with the same name (Slimproto expects a fresh stream per STRM-start).
+func stageToFile(url, dir, baseName string) (stageResult, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return stageResult{}, fmt.Errorf("create stage dir: %w", err)
+	}
+	path := filepath.Join(dir, baseName)
+
+	log.Printf("slimproto: staging %s -> %s", url, path)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return stageResult{}, fmt.Errorf("fetch stream: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return stageResult{StatusCode: resp.StatusCode},
+			fmt.Errorf("stream HTTP %d", resp.StatusCode)
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return stageResult{}, fmt.Errorf("create stage file: %w", err)
+	}
+	n, err := io.Copy(f, resp.Body)
+	closeErr := f.Close()
+	if err != nil {
+		os.Remove(path)
+		return stageResult{}, fmt.Errorf("write stage file: %w", err)
+	}
+	if closeErr != nil {
+		return stageResult{}, fmt.Errorf("close stage file: %w", closeErr)
+	}
+
+	return stageResult{Path: path, BytesRead: n, StatusCode: resp.StatusCode}, nil
+}


### PR DESCRIPTION
Adds a Slimproto (Lyrion/Squeezebox) client so direttampd can register with an LMS server as a software player. LMS drives transport; each STRM-start is staged to a local file and handed to the existing Player + MemoryPlay backend unchanged (fetch-then-play).

Also renames --daemon to --mpd so the two control frontends read symmetrically, and makes them mutually exclusive.

- internal/slimproto: clean-room Slimproto implementation (framing, HELO, STAT, STRM, UDP auto-discovery) decoupled from the player package via a Controller interface so it tests without the CGo Diretta SDK.
- cmd/direttampd: new --slimproto / --slim-server / --slim-name / --slim-mac flags and a runSlimproto entry point; slimproto_adapter wires *player.Player to slimproto.Controller.
- README / Dockerfile / docker-compose: --daemon -> --mpd and a Slimproto-mode section.